### PR TITLE
fix: Handle arrays that are 2+ elements shorter than a power of two

### DIFF
--- a/src/util/__tests__/trimZeros.spec.js
+++ b/src/util/__tests__/trimZeros.spec.js
@@ -1,0 +1,34 @@
+const { trimZeros } = require("../trimZeros");
+
+describe.only("trimZeros", () => {
+  test(`Given an array with a length that is a power of two 
+        It should return the array unchanged`, () => {
+    const array = new Uint8Array(128);
+
+    const actual = trimZeros(array);
+    const expected = array;
+
+    expect(actual).toBe(expected);
+  });
+
+  test(`Given an array with a length that is one less than a power of two
+        It should return a new array with a length that is a power of two padded with zeros`, () => {
+    const array = new Uint8Array(127).fill(1);
+
+    const actual = trimZeros(array);
+    const expected = new Uint8Array([0, ...array]);
+
+    expect(actual).toEqual(expected);
+  });
+
+  test(`Given an array with a length that is two less than a power of two
+        It should throw an exception`, () => {
+    const array = new Uint8Array(126).fill(1);
+
+    expect(() => trimZeros(array)).toThrow("uint8array.length = 126 which is wild");
+  });
+
+  // Interesting edge cases
+  test.todo("Given an empty array it should ____");
+  test.todo("Given an array with one element that is zero it should ____");
+});

--- a/src/util/__tests__/trimZeros.spec.js
+++ b/src/util/__tests__/trimZeros.spec.js
@@ -1,7 +1,7 @@
 const { trimZeros } = require("../trimZeros");
 
 describe.only("trimZeros", () => {
-  test(`Given an array with a length that is a power of two 
+  test(`Given an array with a length that is a power of two
         It should return the array unchanged`, () => {
     const array = new Uint8Array(128);
 
@@ -25,7 +25,10 @@ describe.only("trimZeros", () => {
         It should throw an exception`, () => {
     const array = new Uint8Array(126).fill(1);
 
-    expect(() => trimZeros(array)).toThrow("uint8array.length = 126 which is wild");
+    const actual = trimZeros(array);
+    const expected = new Uint8Array([0, 0, ...array]);
+
+    expect(actual).toEqual(expected);
   });
 
   // Interesting edge cases

--- a/src/util/trimZeros.js
+++ b/src/util/trimZeros.js
@@ -8,8 +8,9 @@ module.exports.trimZeros = function trimZeros(uint8array) {
     return uint8array;
   } else if (n === uint8array.length - 1 && uint8array[0] === 0) {
     return uint8array.slice(1);
-  } else if (n * 2 === uint8array.length + 1) {
-    return concatenate([new Uint8Array([0]), uint8array]);
+  } else if (uint8array.length < Math.pow(2, n)) {
+    const padStart = 2 * n - uint8array.length;
+    return concatenate([new Uint8Array(padStart), uint8array]);
   } else {
     throw new Error(`uint8array.length = ${uint8array.length} which is wild`);
   }


### PR DESCRIPTION
Hey Billie, I've been working with @jcubic on isomorphic-git. Would you consider a bug fix and patch release for this package? Let us know if/how we can help.

The other day I saw this unexpected message from a failing isomorphic-git unit test:

```
uint8array.length = 126 which is wild
```

I've traced the message back to this repo and am confident the PR will fix it. This PR changes the behaviour to zero pad more than one element, like the wild 126.

All the best from Ottawa, Canada! 👋 
